### PR TITLE
Final fixes before upstreaming - several fixes

### DIFF
--- a/src/main.ml
+++ b/src/main.ml
@@ -59,12 +59,16 @@ let programs_arg =
     let g l = List.map (fun x -> (x, f x)) l in
     Term.(pure g $ t) in
   let elf_args =
-    let doc = "Native ELF (Linux) binaries. Requires the $(b,owee) library. For better results, the binary file should have been compiled with debug information." in
+    let doc = "Native ELF (Linux) binaries. Requires the $(b,owee) library. \
+               For better results, the binary file should have been compiled \
+               with debug information." in
     let i = Arg.info ~doc ~docs:"FORMATS" ~docv:"BIN,..." ["elf"] in
     annot (fun _ -> Elf) @@ flatten Arg.(value & opt_all (list file) [] i)
   in
   let guess_args =
-    let doc = "OCaml compiled files that need to be analyzed. Can be one of formats described in $(b,FORMATS). By default, the format is guessed."
+    let doc = "OCaml compiled files that need to be analyzed. Can be one of \
+               formats described in $(b,FORMATS). By default, the format is \
+               guessed."
     in
     let i = Arg.info ~doc ~docv:"FILE" [] in
     annot guess Arg.(value & pos_all file [] i)

--- a/src/treemap.ml
+++ b/src/treemap.ml
@@ -437,23 +437,25 @@ svg {
 
 end
 
-let to_svg tree = Render.svg tree, Render.css
-(** [Treemap.to_svg tree] returns a tuple of the interactive treemap-SVG and 
-    the CSS. The SVG won't render correctly without the CSS. 
-
-    The scale-SVG is not included. Use [Render.Scale.make] for this. *)
-                                     
 let to_html = Render.html
-(** [Treemap.to_html ?override_css tree] returns HTML ready to render the
-    interactive treemap-SVG *)
+(** [Treemap.to_html ?override_css tree] renders the interactive Treemap-SVG 
+    as HTML including the needed CSS*)
 
 let to_html_with_scale = Render.html_with_scale
 (** [Treemap.to_html_with_scale ?override_css ~binary_size ~scale_chunks tree] 
-    returns HTML ready to render the interactive treemap-SVG. It also 
-    includes a scale-SVG that shows the size of data rendered by the 
-    treemap relative to the binary size and other 'chunks' of data. 
+    Renders both the interactive Treemap-SVG and Scale-SVG as HTML, 
+    including their needed CSS. 
+    The Scale-SVG shows the size of data rendered by the Treemap, relative to 
+    the binary size and other 'scale_chunks' of data. 
 
     The [scale_chunks] is a list of names and sizes of chunks of the binary,
-    which are not included in the treemap. *)
+    which are not included in the treemap. Can e.g. be used to show excluded
+    modules.
+
+    The full [binary_size] in bytes needs to be supplied. 
+
+    [override_css] lets you supply a CSS string that is appended, which 
+    therefore lets you add new, or override existing CSS selectors.
+*)
 
 

--- a/src/treemap.ml
+++ b/src/treemap.ml
@@ -245,13 +245,13 @@ svg {
     let rec svg_rect level (T.Node ((info,r), a)) =
       if Array.length a = 0 then
         let eps = 0.0001 in
-        if info.size < eps then Svg.g [] else
-          leaf ~info r
+        if info.size < eps then None else
+          Some (leaf ~info r)
       else
         let children = svg_rects (level+1) @@ Iter.of_array a in
-        node ~info r children
+        Some (node ~info r children)
     and svg_rects level a =
-      Iter.map (svg_rect level) a |> Iter.to_list
+      Iter.filter_map (svg_rect level) a |> Iter.to_list
 
     let make r trees =
       let a = [ viewbox_of_rect r ]

--- a/src/treemap.ml
+++ b/src/treemap.ml
@@ -244,7 +244,9 @@ svg {
 
     let rec svg_rect level (T.Node ((info,r), a)) =
       if Array.length a = 0 then
-        leaf ~info r
+        let eps = 0.0001 in
+        if info.size < eps then Svg.g [] else
+          leaf ~info r
       else
         let children = svg_rects (level+1) @@ Iter.of_array a in
         node ~info r children
@@ -252,14 +254,8 @@ svg {
       Iter.map (svg_rect level) a |> Iter.to_list
 
     let make r trees =
-      let a = [
-        (* a_style "width:100%;height:auto"; *)
-        viewbox_of_rect r ;
-      ]
-      and t = (
-        svg_rects 0 trees
-      )
-      in
+      let a = [ viewbox_of_rect r ]
+      and t = svg_rects 0 trees in
       a, t
 
   end

--- a/tree_layout/dune
+++ b/tree_layout/dune
@@ -1,7 +1,7 @@
 (library
- (name        tree_layout)
- (public_name        modulectomy.tree_layout)
- (synopsis  "Algorithms to layout trees in a pretty manner")
+ (name tree_layout)
+ (public_name modulectomy.tree_layout)
+ (synopsis "Algorithms to layout trees in a pretty manner")
  (ocamlopt_flags (:standard -O3))
  (libraries iter)
 )


### PR DESCRIPTION
This started out being small fixes - but now includes bigger changes too. If you  want the fixes to be made into separate PR's, I'll do that. The changes are: 
* Scoping of all CSS classes, making modulectomy SVG + CSS output more compatible for inclusion in existing HTML doc
* Bettering documentation of main output functions 
* Filtered rendering of leaves in Treemap with size ~= 0 <- this lead to Nan values in SVG 