### PR TITLE
Update to owee.0.5

### DIFF
--- a/modulectomy.opam
+++ b/modulectomy.opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/Drup/modulectomy/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune"
-  "owee"
+  "owee" {>= "0.5"}
   "iter"
   "containers"
   "containers-data"

--- a/src/elf.ml
+++ b/src/elf.ml
@@ -53,9 +53,10 @@ module AddrTbl = CCHashtbl.Make(CCInt64)
 
 let mk_location_tbl buffer sections =
   Owee_elf.find_section sections ".debug_line" >|= fun section ->
-  let body = Owee_buf.cursor (Owee_elf.section_body buffer section) in
+  let pointers_to_other_sections = Owee_elf.debug_line_pointers buffer sections
+  and body = Owee_buf.cursor (Owee_elf.section_body buffer section) in
   let rec aux tbl =
-    match Owee_debug_line.read_chunk body with
+    match Owee_debug_line.read_chunk ~pointers_to_other_sections body with
     | None -> tbl
     | Some (header, chunk) ->
       let check header state tbl =


### PR DESCRIPTION
`Owee_debug_line.read_chunk` now takes a labeled argument `pointers_to_other_sections`. From the CHANGES file and `Owee_debug_line` documentation it is a bit unclear how to construct such a value. I found in one of the examples that you can use `Owee_elf.debug_line_pointers`:

https://github.com/let-def/owee/blob/834302b643e501a1e7b04b6f4bbaee6cd6874c4b/examples/decodedline_elf.ml#L19